### PR TITLE
put value of option -replyTo into MessageHeaders

### DIFF
--- a/tStomp.tcl
+++ b/tStomp.tcl
@@ -586,6 +586,11 @@ class tStomp {
 
 			set headers(expires) [format %.0f [expr $option(ttl) == 0 ? 0 : ([clock seconds] * 1000.0 + $option(ttl))]]
 		}
+
+        # Java javax.jms.Message.getJMSReplyTo() expect replyTo in JMSReplyTo
+		if {$option(replyTo) != ""} {
+            set headers(JMSReplyTo) $option(replyTo)
+        }
 		
 		set specialOptionMap {
 			correlationId correlation-id


### PR DESCRIPTION
Without this change only a Message Property 'reply-to' was created.
Java javax.jms.Message.getJMSReplyTo() expect replyTo in JMSReplyTo
For backward compatibility the Property ist still created.